### PR TITLE
Atari 7800 Proline/gamepad: Change joystick to d-pad buttons

### DIFF
--- a/addons/game.controller.atari.7800.gamepad/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.atari.7800.gamepad/resources/language/resource.language.en_gb/strings.po
@@ -29,25 +29,37 @@ msgid "Button 2"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Joystick"
+msgid "Up"
 msgstr ""
 
 msgctxt "#30004"
-msgid "Reset"
+msgid "Right"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Select"
+msgid "Down"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Pause"
+msgid "Left"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Left Difficulty A"
+msgid "Reset"
 msgstr ""
 
 msgctxt "#30008"
+msgid "Select"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Pause"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Left Difficulty A"
+msgstr ""
+
+msgctxt "#30011"
 msgid "Right Difficulty B"
 msgstr ""

--- a/addons/game.controller.atari.7800.gamepad/resources/layout.xml
+++ b/addons/game.controller.atari.7800.gamepad/resources/layout.xml
@@ -3,13 +3,16 @@
   <category name="face" label="35074">
     <button name="button1" type="digital" label="30001"/>
     <button name="button2" type="digital" label="30002"/>
-    <analogstick name="joystick" label="30003"/>
+    <button name="up" type="digital" label="30003"/>
+    <button name="right" type="digital" label="30004"/>
+    <button name="down" type="digital" label="30005"/>
+    <button name="left" type="digital" label="30006"/>
   </category>
   <category name="hardware" label="35107">
-    <button name="reset" type="digital" label="30004"/>
-    <button name="select" type="digital" label="30005"/>
-    <button name="pause" type="digital" label="30006"/>
-    <button name="leftdifficulty" type="digital" label="30007"/>
-    <button name="rightdifficulty" type="digital" label="30008"/>
+    <button name="reset" type="digital" label="30007"/>
+    <button name="select" type="digital" label="30008"/>
+    <button name="pause" type="digital" label="30009"/>
+    <button name="leftdifficulty" type="digital" label="30010"/>
+    <button name="rightdifficulty" type="digital" label="30011"/>
   </category>
 </layout>

--- a/addons/game.controller.atari.7800.proline/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.atari.7800.proline/resources/language/resource.language.en_gb/strings.po
@@ -29,25 +29,37 @@ msgid "Button 2"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Joystick"
+msgid "Up"
 msgstr ""
 
 msgctxt "#30004"
-msgid "Reset"
+msgid "Right"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Select"
+msgid "Down"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Pause"
+msgid "Left"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Left Difficulty A"
+msgid "Reset"
 msgstr ""
 
 msgctxt "#30008"
+msgid "Select"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Pause"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Left Difficulty A"
+msgstr ""
+
+msgctxt "#30011"
 msgid "Right Difficulty B"
 msgstr ""

--- a/addons/game.controller.atari.7800.proline/resources/layout.xml
+++ b/addons/game.controller.atari.7800.proline/resources/layout.xml
@@ -3,13 +3,16 @@
   <category name="face" label="35074">
     <button name="button1" type="digital" label="30001"/>
     <button name="button2" type="digital" label="30002"/>
-    <analogstick name="joystick" label="30003"/>
+    <button name="up" type="digital" label="30003"/>
+    <button name="right" type="digital" label="30004"/>
+    <button name="down" type="digital" label="30005"/>
+    <button name="left" type="digital" label="30006"/>
   </category>
   <category name="hardware" label="35107">
-    <button name="reset" type="digital" label="30004"/>
-    <button name="select" type="digital" label="30005"/>
-    <button name="pause" type="digital" label="30006"/>
-    <button name="leftdifficulty" type="digital" label="30007"/>
-    <button name="rightdifficulty" type="digital" label="30008"/>
+    <button name="reset" type="digital" label="30007"/>
+    <button name="select" type="digital" label="30008"/>
+    <button name="pause" type="digital" label="30009"/>
+    <button name="leftdifficulty" type="digital" label="30010"/>
+    <button name="rightdifficulty" type="digital" label="30011"/>
   </category>
 </layout>


### PR DESCRIPTION
Analog stick-to-dpad conversion is not implemented in game.libretro yet, for now we'll need to map the D-pad directions instead of rotating a joystick.