### PR TITLE
[master] Fixes for addon.xml descriptions

### DIFF
--- a/addons/game.controller.intellivision/addon.xml
+++ b/addons/game.controller.intellivision/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">Intellivision controller</summary>
-        <description lang="en_GB">The Intellivision, a portmanteau of "intelligent television", was released by Mattel Electronics in 1979. In 2009, IGN named the Intellivision the 14th greatest console of all time.</description>
+        <description lang="en_GB">The Intellivision, a portmanteau of \"intelligent television\", was released by Mattel Electronics in 1979. In 2009, IGN named the Intellivision the 14th greatest console of all time.</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.intellivision/addon.xml
+++ b/addons/game.controller.intellivision/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">Intellivision controller</summary>
-        <description lang="en_GB">The Intellivision, a portmanteau of \"intelligent television\", was released by Mattel Electronics in 1979. In 2009, IGN named the Intellivision the 14th greatest console of all time.</description>
+        <description lang="en_GB">The Intellivision, a portmanteau of &quot;intelligent television&quot;, was released by Mattel Electronics in 1979. In 2009, IGN named the Intellivision the 14th greatest console of all time.</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.n64/addon.xml
+++ b/addons/game.controller.n64/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">Nintendo 64 controller</summary>
-        <description lang="en_GB">The Nintendo 64 controller, released in 1996, featured a unique \"M\" shape design. Intense rotating of the analog stick during Mario Party reportedly caused burn injuries to some players.</description>
+        <description lang="en_GB">The Nintendo 64 controller, released in 1996, featured a unique &quot;M&quot; shape design. Intense rotating of the analog stick during Mario Party reportedly caused burn injuries to some players.</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.n64/addon.xml
+++ b/addons/game.controller.n64/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">Nintendo 64 controller</summary>
-        <description lang="en_GB">The Nintendo 64 controller, released in 1996, featured a unique "M" shape design. Intense rotating of the analog stick during Mario Party reportedly caused burn injuries to some players.</description>
+        <description lang="en_GB">The Nintendo 64 controller, released in 1996, featured a unique \"M\" shape design. Intense rotating of the analog stick during Mario Party reportedly caused burn injuries to some players.</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.nds/addon.xml
+++ b/addons/game.controller.nds/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">Nintendo DS</summary>
-        <description lang="en_GB">The Nintendo DS (short for \"Dual Screen\") is a 32-bit handheld video game console released in 2004. A DS Lite model was launched in 2006, followed by the DSi. Combined, these are the best selling handheld to date, and second best console (behind the PlayStation 2).</description>
+        <description lang="en_GB">The Nintendo DS (short for &quot;Dual Screen&quot;) is a 32-bit handheld video game console released in 2004. A DS Lite model was launched in 2006, followed by the DSi. Combined, these are the best selling handheld to date, and second best console (behind the PlayStation 2).</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.nds/addon.xml
+++ b/addons/game.controller.nds/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">Nintendo DS</summary>
-        <description lang="en_GB">The Nintendo DS (short for "Dual Screen") is a 32-bit handheld video game console released in 2004. A DS Lite model was launched in 2006, followed by the DSi. Combined, these are the best selling handheld to date, and second best console (behind the PlayStation 2).</description>
+        <description lang="en_GB">The Nintendo DS (short for \"Dual Screen\") is a 32-bit handheld video game console released in 2004. A DS Lite model was launched in 2006, followed by the DSi. Combined, these are the best selling handheld to date, and second best console (behind the PlayStation 2).</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.nes/addon.xml
+++ b/addons/game.controller.nes/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">NES controller</summary>
-        <description lang="en_GB">The Nintendo Entertainment System, also known as the Famicom (for \"Family Computer\"), was released in 1983. The cross-shaped directional pad was designed for Game &amp; Watch systems, replacing the bulkier joysticks found on earlier controllers.</description>
+        <description lang="en_GB">The Nintendo Entertainment System, also known as the Famicom (for &quot;Family Computer&quot;), was released in 1983. The cross-shaped directional pad was designed for Game &amp; Watch systems, replacing the bulkier joysticks found on earlier controllers.</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>

--- a/addons/game.controller.nes/addon.xml
+++ b/addons/game.controller.nes/addon.xml
@@ -10,7 +10,7 @@
             <icon>resources/icon.png</icon>
         </assets>
         <summary lang="en_GB">NES controller</summary>
-        <description lang="en_GB">The Nintendo Entertainment System, also known as the Famicom (for "Family Computer"), was released in 1983. The cross-shaped directional pad was designed for Game &amp; Watch systems, replacing the bulkier joysticks found on earlier controllers.</description>
+        <description lang="en_GB">The Nintendo Entertainment System, also known as the Famicom (for \"Family Computer\"), was released in 1983. The cross-shaped directional pad was designed for Game &amp; Watch systems, replacing the bulkier joysticks found on earlier controllers.</description>
         <disclaimer lang="en_GB">Image credit: OpenEmu (openemu.org)</disclaimer>
     </extension>
 </addon>


### PR DESCRIPTION
This fixes errors in addon.xml descriptions.

Descriptions in those 4 addons contain `"` characters, where they should be `&quot;`.