### PR TITLE
Keyboard: Fix typo (IMB -> IBM)

### DIFF
--- a/addons/game.controller.keyboard/addon.xml
+++ b/addons/game.controller.keyboard/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.keyboard"
-        name="IMB Model M Keyboard"
-        version="1.1.15"
+        name="IBM Model M Keyboard"
+        version="1.1.16"
         provider-name="Team Kodi">
     <extension point="kodi.game.controller" library="resources/layout.xml"/>
     <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
## Description

As PR title says. Noticed by @fuzzard https://github.com/xbmc/xbmc/pull/21182#pullrequestreview-920805819

I did a case-insensitive grep for "imb" and it turned up nowhere else except git history.