### PR TITLE
Add "Analog" button to PS controllers

### DIFF
--- a/addons/game.controller.ps.dualanalog/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.ps.dualanalog/resources/language/resource.language.en_gb/strings.po
@@ -91,3 +91,7 @@ msgstr ""
 msgctxt "#30016"
 msgid "R2"
 msgstr ""
+
+msgctxt "#30017"
+msgid "Analog"
+msgstr ""

--- a/addons/game.controller.ps.dualanalog/resources/layout.xml
+++ b/addons/game.controller.ps.dualanalog/resources/layout.xml
@@ -7,6 +7,7 @@
 		<button name="square" type="digital" label="30004"/>
 		<button name="start" type="digital" label="30005"/>
 		<button name="select" type="digital" label="30006"/>
+		<button name="analog" type="digital" label="30017"/>
 		<button name="up" type="digital" label="30007"/>
 		<button name="right" type="digital" label="30008"/>
 		<button name="down" type="digital" label="30009"/>

--- a/addons/game.controller.ps.dualshock/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.ps.dualshock/resources/language/resource.language.en_gb/strings.po
@@ -91,3 +91,7 @@ msgstr ""
 msgctxt "#30016"
 msgid "R2"
 msgstr ""
+
+msgctxt "#30017"
+msgid "Analog"
+msgstr ""

--- a/addons/game.controller.ps.dualshock/resources/layout.xml
+++ b/addons/game.controller.ps.dualshock/resources/layout.xml
@@ -7,6 +7,7 @@
 		<button name="square" type="digital" label="30004"/>
 		<button name="start" type="digital" label="30005"/>
 		<button name="select" type="digital" label="30006"/>
+		<button name="analog" type="digital" label="30017"/>
 		<button name="up" type="digital" label="30007"/>
 		<button name="right" type="digital" label="30008"/>
 		<button name="down" type="digital" label="30009"/>


### PR DESCRIPTION
## Description

As title says, this PR adds another button to the PS Dual Analog and PS Dualshock controllers.

The reason is to allow the PS4 controller to map the center PS button. Currently, the only way to map it is using the default profile because it has the Guide button. However, making the Analog button mappable means that PS4 controllers can be mapped to PS profiles.

The Analog button doesn't actually give any input in games, but it allows translation of the button to Guide in the GUI.

## Motivation and context

I wanted to map the middle PS button on my PS4 controller, and realized that both images show a middle button that we could easily map:

![PS Dual Analog](https://github.com/kodi-game/controller-topology-project/blob/master/addons/game.controller.ps.dualanalog/resources/layout.png?raw=true)

![PS Dualshock](https://github.com/kodi-game/controller-topology-project/blob/master/addons/game.controller.ps.dualshock/resources/layout.png?raw=true)

## How has this been tested?

Produced the following screenshot:

![Screenshot from 2023-02-22 20-34-45](https://user-images.githubusercontent.com/531482/221070036-b46bfc19-b51a-463f-ae92-d85fd9c0e9ff.png)