### PR TITLE
Fix mouse typo

### DIFF
--- a/addons/game.controller.genesis.mouse/addon.xml
+++ b/addons/game.controller.genesis.mouse/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.genesis.mouse"
         name="Genesis Mouse"
-        version="1.0.32"
+        version="1.0.33"
         provider-name="Team Kodi">
     <extension point="kodi.game.controller" library="resources/layout.xml"/>
     <extension point="xbmc.addon.metadata">

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.af_za/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.af_za/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.am_et/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.am_et/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ar_sa/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ar_sa/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ast_es/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ast_es/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.az_az/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.az_az/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.be_by/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.be_by/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.bg_bg/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.bg_bg/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.bs_ba/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.bs_ba/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ca_es/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ca_es/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.cs_cz/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.cs_cz/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.cy_gb/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.cy_gb/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.da_dk/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.da_dk/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Højre knap"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Midterste knap"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.de_de/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.de_de/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Rechte Taste"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Mittlere Taste"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.el_gr/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.el_gr/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.en_au/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.en_au/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.en_gb/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.en_nz/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.en_nz/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.en_us/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.en_us/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.eo/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.eo/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.es_ar/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.es_ar/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.es_es/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.es_es/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Botón derecho"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Botón central"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.es_mx/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.es_mx/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Botón derecho"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Botón medio"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.et_ee/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.et_ee/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.eu_es/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.eu_es/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.fa_af/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.fa_af/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.fa_ir/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.fa_ir/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.fi_fi/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.fi_fi/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Oikea painike"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Keskipainike"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.fo_fo/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.fo_fo/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.fr_ca/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.fr_ca/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.fr_fr/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.fr_fr/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Bouton droit"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Bouton du milieu"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.gl_es/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.gl_es/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.he_il/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.he_il/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.hi_in/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.hi_in/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.hr_hr/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.hr_hr/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.hu_hu/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.hu_hu/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.hy_am/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.hy_am/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.id_id/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.id_id/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.is_is/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.is_is/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.it_it/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.it_it/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Tasto destro"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Tasto centrale"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ja_jp/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ja_jp/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.kn_in/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.kn_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ko_kr/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ko_kr/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.lt_lt/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.lt_lt/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.lv_lv/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.lv_lv/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.mi/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.mi/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.mk_mk/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.mk_mk/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ml_in/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ml_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.mn_mn/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.mn_mn/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ms_my/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ms_my/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.mt_mt/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.mt_mt/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.my_mm/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.my_mm/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.nb_no/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.nb_no/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.nl_nl/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.nl_nl/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.oc_fr/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.oc_fr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.os_os/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.os_os/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.pl_pl/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.pl_pl/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Prawy przycisk"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Środkowy przycisk"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.pt_br/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.pt_br/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.pt_pt/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.pt_pt/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ro_ro/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ro_ro/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ru_ru/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ru_ru/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Правая кнопка"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Средняя кнопка"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.si_lk/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.si_lk/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.sk_sk/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.sk_sk/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.sl_si/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.sl_si/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.sq_al/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.sq_al/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.sr_rs/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.sr_rs/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.sr_rs@latin/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.sv_se/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.sv_se/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.szl/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.szl/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.ta_in/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.ta_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.te_in/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.te_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.tg_tj/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.tg_tj/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.th_th/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.th_th/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.tr_tr/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.tr_tr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.uk_ua/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.uk_ua/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.uz_uz/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.uz_uz/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.vi_vn/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.vi_vn/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.zh_cn/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.zh_cn/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "右按钮"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "中按钮"
 
 msgctxt "#30004"

--- a/addons/game.controller.genesis.mouse/resources/language/resource.language.zh_tw/strings.po
+++ b/addons/game.controller.genesis.mouse/resources/language/resource.language.zh_tw/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/addon.xml
+++ b/addons/game.controller.mouse/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.mouse"
         name="Computer Mouse"
-        version="1.0.22"
+        version="1.0.23"
         provider-name="Team Kodi">
     <extension point="kodi.game.controller" library="resources/layout.xml"/>
     <extension point="xbmc.addon.metadata">

--- a/addons/game.controller.mouse/resources/language/resource.language.af_za/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.af_za/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.am_et/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.am_et/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ar_sa/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ar_sa/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ast_es/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ast_es/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.az_az/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.az_az/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.be_by/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.be_by/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.bg_bg/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.bg_bg/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.bs_ba/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.bs_ba/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ca_es/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ca_es/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.cs_cz/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.cs_cz/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.cy_gb/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.cy_gb/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.da_dk/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.da_dk/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Højre knap"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Midterste knap"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.de_de/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.de_de/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Rechte Taste"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Mittlere Taste"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.el_gr/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.el_gr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.en_au/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.en_au/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.en_gb/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.en_nz/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.en_nz/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.en_us/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.en_us/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.eo/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.eo/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.es_ar/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.es_ar/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.es_es/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.es_es/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Botón derecho"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Botón central"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.es_mx/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.es_mx/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Botón derecho"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Botón medio"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.et_ee/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.et_ee/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.eu_es/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.eu_es/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.fa_af/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.fa_af/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.fa_ir/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.fa_ir/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.fi_fi/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.fi_fi/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Oikea painike"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Keskipainike"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.fo_fo/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.fo_fo/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.fr_ca/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.fr_ca/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.fr_fr/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.fr_fr/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Bouton droit"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Bouton du milieu"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.gl_es/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.gl_es/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.he_il/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.he_il/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.hi_in/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.hi_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.hr_hr/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.hr_hr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.hu_hu/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.hu_hu/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.hy_am/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.hy_am/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.id_id/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.id_id/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.is_is/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.is_is/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.it_it/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.it_it/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Tasto destro"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Tasto centrale"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ja_jp/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ja_jp/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.kn_in/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.kn_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ko_kr/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ko_kr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.lt_lt/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.lt_lt/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.lv_lv/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.lv_lv/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.mi/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.mi/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.mk_mk/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.mk_mk/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ml_in/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ml_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.mn_mn/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.mn_mn/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ms_my/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ms_my/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.mt_mt/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.mt_mt/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.my_mm/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.my_mm/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.nb_no/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.nb_no/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.nl_nl/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.nl_nl/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.oc_fr/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.oc_fr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.os_os/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.os_os/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.pl_pl/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.pl_pl/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Prawy przycisk"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Środkowy przycisk"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.pt_br/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.pt_br/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.pt_pt/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.pt_pt/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ro_ro/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ro_ro/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ru_ru/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ru_ru/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "Правая кнопка"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "Средняя кнопка"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.si_lk/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.si_lk/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.sk_sk/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.sk_sk/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.sl_si/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.sl_si/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.sq_al/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.sq_al/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.sr_rs/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.sr_rs/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.sr_rs@latin/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.sv_se/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.sv_se/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.szl/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.szl/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.ta_in/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.ta_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.te_in/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.te_in/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.tg_tj/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.tg_tj/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.th_th/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.th_th/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.tr_tr/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.tr_tr/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.uk_ua/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.uk_ua/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.uz_uz/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.uz_uz/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.vi_vn/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.vi_vn/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.zh_cn/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.zh_cn/strings.po
@@ -38,7 +38,7 @@ msgid "Right button"
 msgstr "右按钮"
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr "中按钮"
 
 msgctxt "#30004"

--- a/addons/game.controller.mouse/resources/language/resource.language.zh_tw/strings.po
+++ b/addons/game.controller.mouse/resources/language/resource.language.zh_tw/strings.po
@@ -37,7 +37,7 @@ msgid "Right button"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Midle button"
+msgid "Middle button"
 msgstr ""
 
 msgctxt "#30004"


### PR DESCRIPTION
## Description

A typo was identified in https://github.com/xbmc/xbmc/issues/23588. This fixes the typo, both for the mouse add-on shipped with Kodi and the Genesis mouse add-on in the repo.

## Related PRs

Fixes https://github.com/xbmc/xbmc/issues/23588

## How has this been tested?

![Screenshot from 2023-08-05 18-56-39](https://github.com/kodi-game/controller-topology-project/assets/531482/4fa566b2-b26a-482c-ace4-c94b35104f9c)

![Screenshot from 2023-08-05 18-56-47](https://github.com/kodi-game/controller-topology-project/assets/531482/08b4da2d-7008-4f06-a670-1da08923771e)