### PR TITLE
Remove non-existing buttons from PS Gamepad

### DIFF
--- a/addons/game.controller.ps.gamepad/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.ps.gamepad/resources/language/resource.language.en_gb/strings.po
@@ -68,13 +68,7 @@ msgctxt "#30010"
 msgid "Left"
 msgstr ""
 
-msgctxt "#30011"
-msgid "Left Stick"
-msgstr ""
-
-msgctxt "#30012"
-msgid "Right Stick"
-msgstr ""
+#empty strings from id 30011 to 30012
 
 msgctxt "#30013"
 msgid "L1"

--- a/addons/game.controller.ps.gamepad/resources/layout.xml
+++ b/addons/game.controller.ps.gamepad/resources/layout.xml
@@ -11,8 +11,6 @@
 		<button name="right" type="digital" label="30008"/>
 		<button name="down" type="digital" label="30009"/>
 		<button name="left" type="digital" label="30010"/>
-		<button name="l3" type="digital" label="30011"/>
-		<button name="r3" type="digital" label="30012"/>
 	</category>
 	<category name="shoulder" label="35075">
 		<button name="leftbumper" type="digital" label="30013"/>
@@ -21,9 +19,5 @@
 	<category name="triggers" label="35076">
 		<button name="lefttrigger" type="digital" label="30015"/>
 		<button name="righttrigger" type="digital" label="30016"/>
-	</category>
-	<category name="haptics">
-		<motor name="strongmotor"/>
-		<motor name="weakmotor"/>
 	</category>
 </layout>


### PR DESCRIPTION
Remove non-existing buttons from PS Gamepad as requested in https://github.com/kodi-game/game.libretro.pcsx-rearmed/pull/26.

I've checked the layout for the PS Dual Analog controller as well, but that one seems to be correct.