### PR TITLE
game.controller.keyboard: Add OEM 102 key (OEM key on 102-key keyboards)

### DIFF
--- a/addons/game.controller.keyboard/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.keyboard/resources/language/resource.language.en_gb/strings.po
@@ -589,3 +589,7 @@ msgstr ""
 msgctxt "#30140"
 msgid "Clear"
 msgstr ""
+
+msgctxt "#30141"
+msgid "OEM 102nd Key"
+msgstr ""

--- a/addons/game.controller.keyboard/resources/layout.xml
+++ b/addons/game.controller.keyboard/resources/layout.xml
@@ -140,5 +140,6 @@
     <key name="power" symbol="power" label="30136"/>
     <key name="euro" symbol="euro" label="30137"/>
     <key name="undo" symbol="undo" label="30138"/>
+    <key name="oem102" symbol="oem102" label="30141"/>
   </category>
 </layout>


### PR DESCRIPTION
## Description

This adds the OEM 102 key (OEM key on 102-key keyboards) to game.controller.keyboard.

## Related PRs

Required by https://github.com/kodi-game/game.libretro/pull/115.

Added to libretro in https://github.com/libretro/RetroArch/pull/7173.