### PR TITLE
keyboard: Rename "Num Pad Equals" to "Num Pad ="

### DIFF
--- a/addons/game.controller.keyboard/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.keyboard/resources/language/resource.language.en_gb/strings.po
@@ -583,7 +583,7 @@ msgid "Undo"
 msgstr ""
 
 msgctxt "#30139"
-msgid "Num Pad Equals"
+msgid "Num Pad ="
 msgstr ""
 
 msgctxt "#30140"


### PR DESCRIPTION
## Description

As title says, this uses the = symbol for the numpad key as we do for the regular keyboard equals key: https://github.com/kodi-game/controller-topology-project/blob/master/addons/game.controller.keyboard/resources/language/resource.language.en_gb/strings.po#L290

```
msgctxt "#30065"
msgid "="
msgstr ""
```

## How has this been tested?

![Screenshot from 2024-02-03 14-59-06](https://github.com/kodi-game/controller-topology-project/assets/531482/fccfd4b5-f0f1-4737-83fb-55982a313118)
