### PR TITLE
Dreamcast: the triggers are analog

### DIFF
--- a/addons/game.controller.dreamcast/resources/layout.xml
+++ b/addons/game.controller.dreamcast/resources/layout.xml
@@ -12,8 +12,8 @@
 		<button name="left" type="digital" label="30009"/>
 	</category>
 	<category name="triggers" label="35076">
-		<button name="lefttrigger" type="digital" label="30010"/>
-		<button name="righttrigger" type="digital" label="30011"/>
+		<button name="lefttrigger" type="analog" label="30010"/>
+		<button name="righttrigger" type="analog" label="30011"/>
 	</category>
 	<category name="analogsticks" label="35077">
 		<analogstick name="analogstick" label="30012"/>


### PR DESCRIPTION
The Dreamcast controller's triggers are analog, but `game.controller.dreamcast` declares them digital:

```xml
<button name="lefttrigger"  type="digital" label="30010"/>
<button name="righttrigger" type="digital" label="30011"/>
```

Games read them as analog. Crazy Taxi accelerates and reverses with them, and Sonic Adventure steers on their travel rather than their state.

Declared digital, the frontend collapses the axis it is given into a press and a release, so the game gets full throttle or nothing — Crazy Taxi cannot be driven at all.

**Every layer below the profile was already correct**, which is what made this slow to find. On an 8BitDo Pro 2 over the udev backend, `peripheral.joystick` had bound them to axes:

```xml
<feature name="lefttrigger"  axis="+2"/>
<feature name="righttrigger" axis="+5"/>
```

and the driver was reporting travel. The give-away is in Kodi's log: the feature only ever appears as

```
FEATURE [ righttrigger ] on game.controller.dreamcast pressed (handled)
FEATURE [ righttrigger ] on game.controller.dreamcast released
```

with no magnitude, however slowly the trigger is pulled.

This changes both to `type="analog"`, matching `game.controller.default`, whose analog triggers are declared the same way.

Tested on real hardware: LibreELEC with flycast, 8BitDo Pro 2, Crazy Taxi.