### PR TITLE
Odyssey2: Give the console keyboard its own buttons

### DIFF
--- a/addons/game.controller.odyssey2/resources/language/resource.language.en_gb/strings.po
+++ b/addons/game.controller.odyssey2/resources/language/resource.language.en_gb/strings.po
@@ -51,3 +51,39 @@ msgstr ""
 msgctxt "#30005"
 msgid "Left"
 msgstr ""
+
+msgctxt "#30006"
+msgid "Move Keyboard"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Toggle Keyboard"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Key 0"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Key 1"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Key 2"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Key 3"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Key 4"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Key 5"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Key 6"
+msgstr ""

--- a/addons/game.controller.odyssey2/resources/layout.xml
+++ b/addons/game.controller.odyssey2/resources/layout.xml
@@ -7,4 +7,15 @@
 		<button name="down" type="digital" label="30004"/>
 		<button name="left" type="digital" label="30005"/>
 	</category>
+	<category name="hardware" label="35108">
+		<button name="vkbmove" type="digital" label="30006"/>
+		<button name="vkbtoggle" type="digital" label="30007"/>
+		<button name="num0" type="digital" label="30008"/>
+		<button name="num1" type="digital" label="30009"/>
+		<button name="num2" type="digital" label="30010"/>
+		<button name="num3" type="digital" label="30011"/>
+		<button name="num4" type="digital" label="30012"/>
+		<button name="num5" type="digital" label="30013"/>
+		<button name="num6" type="digital" label="30014"/>
+	</category>
 </layout>


### PR DESCRIPTION
Moved here from garbear/xbmc#159 at @garbear's request. Option 1 from https://github.com/kodi-game/game.libretro.o2em/pull/6#issuecomment-5543829524.

The Odyssey² controller is a joystick and a single action button, so that is all the profile described. But the console itself carries a keyboard that games read, and o2em drives it from the joypad — which left the keypad games unplayable, with no feature to bind the keys to. Games sit on the BIOS "SELECT GAME" screen forever, because that screen is asking for a digit.

The new buttons go in `hardware`, which `categories.po` already describes as "buttons that control the game console hardware" — the same category the Pokémon Mini shake button was moved into.

| Feature | Core descriptor |
|---|---|
| `vkbmove` | Move Virtual Keyboard |
| `vkbtoggle` | Show/Hide Virtual Keyboard |
| `num0` … `num6` | Numeric Key 0 … 6 |

Labels are kept short as requested — "Move Keyboard", "Toggle Keyboard", then "Key 0" through "Key 6".

The buttonmap that binds these is kodi-game/game.libretro.o2em#7, which needs these feature names to exist.

Following the precedent of `amiga.cd32: Add "Select" button` and `Atari 2600: Add joysticks category`, this touches `en_gb` only and leaves `addon.xml` alone, since the version increment is automated.

Worth knowing: the core declares the keypad for **player one only**, so port 2 is deliberately untouched.